### PR TITLE
Python 3.12 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Why the console?  Because it's the *cool* way.
 
 ![What periodic-table-cli prints to the console](https://raw.githubusercontent.com/spirometaxas/periodic-table-cli-py/main/img/animated_5mb.gif)
 
-[![pypi version](https://img.shields.io/pypi/v/periodic-table-cli)](https://pypi.org/project/periodic-table-cli/)
-[![status](https://img.shields.io/pypi/status/periodic-table-cli)](https://pypi.org/project/periodic-table-cli/)
+[![pypi version](https://img.shields.io/pypi/v/periodic-table-cli.svg)](https://pypi.org/project/periodic-table-cli/)
+[![status](https://img.shields.io/pypi/status/periodic-table-cli.svg)](https://pypi.org/project/periodic-table-cli/)
 [![downloads](https://static.pepy.tech/personalized-badge/periodic-table-cli?period=total&units=abbreviation&left_color=grey&right_color=green&left_text=downloads)](https://www.pepy.tech/projects/periodic-table-cli)
-[![license](https://img.shields.io/pypi/l/periodic-table-cli)](https://github.com/spirometaxas/periodic-table-cli-py/blob/main/LICENSE)
+[![license](https://img.shields.io/pypi/l/periodic-table-cli.svg)](https://github.com/spirometaxas/periodic-table-cli-py/blob/main/LICENSE)
 
 Also available for [NodeJS](https://www.npmjs.com/package/periodic-table-cli).  View [Homepage](https://spirometaxas.com/projects/periodic-table-cli).
 

--- a/periodic_table_cli/cli.py
+++ b/periodic_table_cli/cli.py
@@ -6,7 +6,6 @@ from .data_processor import DataProcessor
 from .chart_processor import ChartProcessor
 from .app import App
 import locale
-import importlib.metadata
 
 class AppConfig:
 
@@ -83,7 +82,7 @@ def print_usage():
         ' ' + get_version() + '\n')
 
 def get_version():
-    return 'v' + importlib.metadata.version('periodic-table-cli') + ' (Python)'
+    return 'v2.0.5 (Python)'
 
 def get_flags(params):
     return [param for param in params if param.startswith('-')]

--- a/periodic_table_cli/cli.py
+++ b/periodic_table_cli/cli.py
@@ -153,6 +153,36 @@ def load_data():
         print('\n Error loading data file.\n')
         sys.exit()
 
+def _wrapper(func):
+    # Using workaround to address windows-curses bug on Python 3.12
+    # More info: https://github.com/zephyrproject-rtos/windows-curses/issues/50
+    if os.name == 'nt' and sys.version_info[0] == 3 and sys.version_info[1] >= 12:
+        stdscr = None
+        try:
+            import _curses
+            # This crashes on Python 3.12.
+            # setupterm(term=_os.environ.get("TERM", "unknown"),
+            # fd=_sys.__stdout__.fileno())
+            stdscr = _curses.initscr()
+            for key, value in _curses.__dict__.items():
+                if key[0:4] == 'ACS_' or key in ('LINES', 'COLS'):
+                    setattr(curses, key, value)
+
+            curses.noecho()
+            curses.cbreak()
+            
+            if stdscr is not None:
+                stdscr.keypad(True)
+                func(stdscr)
+        finally:
+            if stdscr is not None:
+                stdscr.keypad(False)
+            curses.nocbreak()
+            curses.echo()
+            curses.endwin()
+    else:
+        curses.wrapper(func)
+
 def main():
     os.system('')  # Enable ANSI escape sequences on Windows
     locale.setlocale(locale.LC_ALL, '')
@@ -194,7 +224,7 @@ def main():
 
     data = load_data()
     app = App(AppConfig(atomic_number, symbol, name), data)
-    curses.wrapper(app.start)
+    _wrapper(app.start)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Adding fix proposed in [this issue](https://github.com/zephyrproject-rtos/windows-curses/issues/50) to address bug on Windows when using Python 3.12.  Also removing deprecated `importlib.metadata` library.  