### PR TITLE
Add scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Note: Supports Python 3.8+.  Zero dependencies except [windows-curses](https://p
 
 Add the `--help` flag for more info.
 
-Note: Be sure to run in terminals that support 256 colors.  Minimum required terminal screen dimensions: 156 columns x 46 rows.
+Note:
+- Be sure to run in terminals that support 256 colors.
+- Minimum required terminal screen dimensions: 156 columns x 46 rows.  [See scrolling](https://github.com/spirometaxas/periodic-table-cli-py#scrolling) for more info. 
 
 ## Features
 ### Browse
@@ -244,6 +246,14 @@ $ periodic-table-cli --mode=app --atomic-number=<number>
 $ periodic-table-cli --mode=app --symbol=<symbol>
 $ periodic-table-cli --mode=app --name=<name>
 ```
+
+### Scrolling
+The minimum required terminal screen dimensions are 156 columns x 46 rows.  When using a smaller screen, some components may be cut off.  To fix this, either make the screen bigger or use scrolling to pan across the screen:
+
+- Use `COMMA` (`,`) to scroll up.
+- Use `PERIOD` (`.`) to scroll down.
+- Use `LEFT CARROT` (`<`) to scroll left.
+- Use `RIGHT CARROT` (`>`) to scroll right.
 
 ## Data Sources
 Data used in the app is stored in an easy to edit [data file](https://github.com/spirometaxas/periodic-table-cli-py/blob/main/periodic_table_cli/data.json).  The data is mostly imported from [PubChem](https://pubchem.ncbi.nlm.nih.gov/periodic-table/). 

--- a/periodic_table_cli/app.py
+++ b/periodic_table_cli/app.py
@@ -126,7 +126,7 @@ class App:
             print(message)
         elif full_rows < MinimumSupportedDimensions.ROWS or full_columns < MinimumSupportedDimensions.COLUMNS:
             print('\n' +
-                ' Warning: Current screen dimensions are smaller than minimum supported dimensions, and some screen components may have been cut off.\n' +
+                ' Tip: Current screen dimensions are smaller than minimum supported dimensions, and some screen components may have been cut off.\n' +
                 ' To fix this, either make the screen bigger or use scrolling to pan across the screen:\n' +
                 '   - Use COMMA (,) to scroll up\n' +
                 '   - Use PERIOD (.) to scroll down\n' +

--- a/periodic_table_cli/dashboard.py
+++ b/periodic_table_cli/dashboard.py
@@ -216,6 +216,7 @@ class Dashboard:
     def __init__(self, data):
         self.data = data
         self.board = self._parse_board()
+        self.scrolling = Point(0, 0)
         self._initDataOnBoard()
         self._save_board()
 
@@ -849,9 +850,45 @@ class Dashboard:
                 if full_rows > len(self.board):
                     r_offset = int((full_rows - len(self.board)) * self.VERTICAL_RATIO)
 
-                full_board[r_offset + r][c_offset + c] = self.board[r][c]
+                full_board[r_offset + r][c_offset + c] = self.board[r + self.scrolling.y][c + self.scrolling.x]
 
         return full_board
+
+    def scroll_up(self):
+        full_rows = self.window.getmaxyx()[0]
+        if full_rows < len(self.board) and self.scrolling.y > 0:
+            self.scrolling.y -= 1
+            return True
+        return False
+
+    def scroll_down(self):
+        full_rows = self.window.getmaxyx()[0]
+        if full_rows < len(self.board) and self.scrolling.y + full_rows < len(self.board):
+            self.scrolling.y += 1
+            return True
+        return False
+
+    def scroll_left(self):
+        full_columns = self.window.getmaxyx()[1]
+        if full_columns < len(self.board[0]) and self.scrolling.x > 0:
+            self.scrolling.x -= 1
+            return True
+        return False
+
+    def scroll_right(self):
+        full_columns = self.window.getmaxyx()[1]
+        if full_columns < len(self.board[0]) and self.scrolling.x + full_columns < len(self.board[0]):
+            self.scrolling.x += 1
+            return True
+        return False
+
+    def update_scrolling_on_resize(self):
+        full_rows, full_columns = self.window.getmaxyx()
+        if self.scrolling.y + full_rows > len(self.board):
+            self.scrolling.y = max(len(self.board) - full_rows, 0)
+
+        if self.scrolling.x + full_columns > len(self.board[0]):
+            self.scrolling.x = max(len(self.board[0]) - full_columns, 0)
 
     def _draw(self):
         full_board = self._get_full_screen_board()


### PR DESCRIPTION
The minimum required terminal screen dimensions are 156 columns x 46 rows.  When using a smaller screen, some components may be cut off.  To fix this, either make the screen bigger or use scrolling to pan across the screen:

- Use `COMMA` (`,`) to scroll up.
- Use `PERIOD` (`.`) to scroll down.
- Use `LEFT CARROT` (`<`) to scroll left.
- Use `RIGHT CARROT` (`>`) to scroll right.