### PR TITLE
Mac Terminal Background Fix

### DIFF
--- a/periodic_table_cli/app.py
+++ b/periodic_table_cli/app.py
@@ -52,6 +52,7 @@ class App:
     def _clear_screen(self, window, full):
         if full:
             window.clear()
+            # Set default background to fix rendering issue on some Mac terminals
             window.bkgd(' ', curses.color_pair(Colors.get_color_pair_id(Colors.WHITE.FG, Colors.DEEP_BLACK.BG)))
         window.move(0, 0)
 

--- a/periodic_table_cli/app.py
+++ b/periodic_table_cli/app.py
@@ -52,6 +52,7 @@ class App:
     def _clear_screen(self, window, full):
         if full:
             window.clear()
+            window.bkgd(' ', curses.color_pair(Colors.get_color_pair_id(Colors.WHITE.FG, Colors.DEEP_BLACK.BG)))
         window.move(0, 0)
 
     def start(self, window):

--- a/periodic_table_cli/colors.py
+++ b/periodic_table_cli/colors.py
@@ -16,6 +16,7 @@ class Color:
 
 class Colors:
     BLACK       = Color({ 'ANSI':   0, 'R':   0, 'G':   0, 'B':   0 })  # Use default black
+    DEEP_BLACK  = Color({ 'ANSI':  16, 'R':   0, 'G':   0, 'B':   0 })
     WHITE       = Color({ 'ANSI': 255, 'R': 238, 'G': 238, 'B': 238 })
     GRAY        = Color({ 'ANSI': 244, 'R': 128, 'G': 128, 'B': 128 })
     LIGHT_GRAY  = Color({ 'ANSI': 250, 'R': 188, 'G': 188, 'B': 188 })
@@ -36,7 +37,7 @@ class Colors:
     PURPLE      = Color({ 'ANSI':  93, 'R': 135, 'G':   0, 'B': 255 })
 
     COLORS = [ 
-        BLACK, WHITE, GRAY, LIGHT_GRAY, FOCUS_GOLD, FOCUS_BLUE,
+        BLACK, DEEP_BLACK, WHITE, GRAY, LIGHT_GRAY, FOCUS_GOLD, FOCUS_BLUE,
         RED, DARK_RED, ORANGE, YELLOW, DARK_YELLOW, GREEN,
         MID_GREEN, DARK_GREEN, SKY_BLUE, BLUE, MAGENTA, PURPLE,
     ]


### PR DESCRIPTION
Setting the default curses background to black (ANSI 16) fixes a rendering issue on some Mac terminals (running Python 3.13) where the black (ANSI 0) background does not fill the entire screen.  

Note: This appears to be Curses related.  Without this fix, it works perfectly fine on Ubuntu terminals (running Python 3.12), along with iTerm2 on Mac with Python 3.13.  The NodeJS implementation also works perfectly fine on the same Mac terminals.  
